### PR TITLE
skip handling of refs that get deleted

### DIFF
--- a/git/post-receive.rb
+++ b/git/post-receive.rb
@@ -68,6 +68,11 @@ STDIN.each_line do |line|
   start_commit_id, end_commit_id, ref = line.strip.split
 end
 
+# skip handling if this ref gets deleted
+if end_commit_id == "0000000000000000000000000000000000000000"
+	exit
+end
+
 # current directory is repository root
 repo_path = Dir.pwd
 repo_name = Pathname.new(repo_path).basename


### PR DESCRIPTION
When pushing and deleting a ref, it does not make sense to trigger a
build. This is the case when the resulting commit id is zero. As the
hook only handles the last ref update we can simply call exit.